### PR TITLE
fix(release): pin yt-dlp 2026.08.19

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ env:
   RELEASE_TAG: ${{ github.event_name == 'release' && github.event.release.tag_name || github.event_name == 'workflow_dispatch' && github.event.inputs.tag || github.ref_name }}
   RELEASE_REF: ${{ github.event_name == 'workflow_dispatch' && format('refs/tags/{0}', github.event.inputs.tag) || github.ref }}
   DENO_VERSION: "2.9.4"
+  YTDLP_VERSION: "2026.08.19"
 
 jobs:
   build:
@@ -76,7 +77,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          python -m pip install build pyinstaller yt-dlp ytmusicapi
+          python -m pip install build pyinstaller "yt-dlp[default]==${YTDLP_VERSION}" ytmusicapi
           python -m pip install -e .
 
       - name: Ensure license directory
@@ -289,11 +290,12 @@ jobs:
               bin_dir = app_dir
               if (app_dir / "CSVMusic").exists() or (app_dir / "CSVMusic.exe").exists():
                   bin_dir = app_dir
-              # Always fetch official standalone yt-dlp for portability
+              # Fetch the tested standalone yt-dlp version for reproducible releases
+              ytdlp_version = os.environ["YTDLP_VERSION"]
               dst_ytdlp = bin_dir / ytdlp_name
               url = (
-                  "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp.exe" if plat_win else
-                  "https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_linux"
+                  f"https://github.com/yt-dlp/yt-dlp/releases/download/{ytdlp_version}/yt-dlp.exe" if plat_win else
+                  f"https://github.com/yt-dlp/yt-dlp/releases/download/{ytdlp_version}/yt-dlp_linux"
               )
               try:
                   import urllib.request

--- a/README.md
+++ b/README.md
@@ -23,21 +23,21 @@ CSVMusic accepts playlist and album links from supported music services, or a pl
 # Download
 
 Go here:
-https://github.com/angall1/CSVMusic/releases/tag/v1.6.3
+https://github.com/angall1/CSVMusic/releases/tag/v1.6.4
 
 Download one of the following based on your OS:
 
 ### Windows
-https://github.com/angall1/CSVMusic/releases/download/v1.6.3/CSVMusic-windows.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.4/CSVMusic-windows.zip
 
 ### macOS (Apple Silicon)
-https://github.com/angall1/CSVMusic/releases/download/v1.6.3/CSVMusic-macos-arm64.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.4/CSVMusic-macos-arm64.zip
 
 ### macOS (Intel)
-https://github.com/angall1/CSVMusic/releases/download/v1.6.3/CSVMusic-macos-intel.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.4/CSVMusic-macos-intel.zip
 
 ### Linux
-https://github.com/angall1/CSVMusic/releases/download/v1.6.3/CSVMusic-linux.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.4/CSVMusic-linux.zip
 
 Extract the ZIP before running the app. If your desktop does not launch the files directly, open a terminal in the extracted folder and run:
 
@@ -64,10 +64,11 @@ Python installations still require a supported graphical desktop environment for
 
 ---
 
-# What's New In 1.6.3 (Since 1.6.0)
+# What's New In 1.6.4 (Since 1.6.0)
 
 ## YouTube reliability
 
+- Updated and pinned yt-dlp to `2026.08.19`, fixing widespread HTTP 403 failures with current YouTube `web_embedded` downloads and preventing release builds from silently changing downloader versions.
 - Fixed current YouTube player-challenge failures by packaging Deno and `yt-dlp-ejs`, passing the runtime explicitly, and validating both before downloads begin.
 - Updated YouTube client fallbacks and diagnostics for current yt-dlp behavior, including clearer HTTP 403, throttling, and JavaScript-runtime messages.
 - Added adaptive pacing when YouTube starts throttling or blocking a playlist download.

--- a/csvmusic/version.py
+++ b/csvmusic/version.py
@@ -1,2 +1,2 @@
 # tabs only
-APP_VERSION = "1.6.3"
+APP_VERSION = "1.6.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,13 +4,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "csvmusic"
-version = "1.6.3"
+version = "1.6.4"
 description = "Convert Spotify playlists to MP3/M4A via YouTube Music (packaged, no extra installs)"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
 	"PySide6>=6.6",
-	"yt-dlp[default]>=2026.6.9",
+	"yt-dlp[default]==2026.8.19",
 	"ytmusicapi>=1.7.4",
 	"mutagen>=1.47.0",
 	"requests>=2.32.0",

--- a/tests/core/test_packaging.py
+++ b/tests/core/test_packaging.py
@@ -41,6 +41,15 @@ def test_release_workflow_fetches_packaged_deno() -> None:
 	assert "licenses/DENO-LICENSE.md" in workflow
 
 
+def test_release_workflow_pins_tested_ytdlp() -> None:
+	workflow = (ROOT / ".github" / "workflows" / "release.yml").read_text(encoding="utf-8")
+
+	assert 'YTDLP_VERSION: "2026.08.19"' in workflow
+	assert '"yt-dlp[default]==${YTDLP_VERSION}"' in workflow
+	assert 'releases/download/{ytdlp_version}/yt-dlp.exe' in workflow
+	assert "releases/latest/download/yt-dlp" not in workflow
+
+
 def test_pyinstaller_collects_deno_and_ejs() -> None:
 	spec = (ROOT / "CSVMusic.spec").read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- release CSVMusic 1.6.4 with yt-dlp 2026.08.19 pinned
- fix widespread YouTube HTTP 403 failures affecting 1.6.3
- make packaged yt-dlp downloads reproducible
- extend cumulative release notes from 1.6.0 through 1.6.4

## Validation

- 77 automated tests passed
- three representative Exportify tracks downloaded successfully as M4A
- pinned yt-dlp executable reports 2026.08.19