### PR TITLE
Release CSVMusic 1.6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,21 @@ CSVMusic accepts playlist and album links from supported music services, or a pl
 # Download
 
 Go here:
-https://github.com/angall1/CSVMusic/releases/tag/v1.6.4
+https://github.com/angall1/CSVMusic/releases/tag/v1.6.5
 
 Download one of the following based on your OS:
 
 ### Windows
-https://github.com/angall1/CSVMusic/releases/download/v1.6.4/CSVMusic-windows.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.5/CSVMusic-windows.zip
 
 ### macOS (Apple Silicon)
-https://github.com/angall1/CSVMusic/releases/download/v1.6.4/CSVMusic-macos-arm64.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.5/CSVMusic-macos-arm64.zip
 
 ### macOS (Intel)
-https://github.com/angall1/CSVMusic/releases/download/v1.6.4/CSVMusic-macos-intel.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.5/CSVMusic-macos-intel.zip
 
 ### Linux
-https://github.com/angall1/CSVMusic/releases/download/v1.6.4/CSVMusic-linux.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.5/CSVMusic-linux.zip
 
 Extract the ZIP before running the app. If your desktop does not launch the files directly, open a terminal in the extracted folder and run:
 
@@ -64,7 +64,12 @@ Python installations still require a supported graphical desktop environment for
 
 ---
 
-# What's New In 1.6.4 (Since 1.6.0)
+# What's New In 1.6.5 (Since 1.6.0)
+
+## Updates and MP3 reliability
+
+- Added a lightweight startup update check that prompts when a newer stable CSVMusic release is available, with options to download, be reminded later, or skip that version.
+- Fixed intermittent MP3 failures when YouTube exposes only a combined audio/video stream. CSVMusic still prefers audio-only downloads and now safely falls back to extracting audio from the best available combined stream.
 
 ## YouTube reliability
 

--- a/csvmusic/core/downloader.py
+++ b/csvmusic/core/downloader.py
@@ -16,6 +16,7 @@ from csvmusic.core.subprocess_env import subprocess_kwargs
 YTM_URL = "https://music.youtube.com/watch?v={vid}"
 YT_URL = "https://www.youtube.com/watch?v={vid}"
 YOUTUBE_CLIENTS: list[str] = ["web_embedded", "ios", "tv", "android_vr"]
+MP3_SOURCE_FORMAT = "bestaudio/best"
 _YOUTUBE_RISK_PATTERNS: tuple[tuple[str, str], ...] = (
 	("http error 429", "YouTube returned HTTP 429"),
 	("too many requests", "YouTube is rate limiting requests"),
@@ -773,7 +774,7 @@ def download_mp3(video_id: str, dst_dir: pathlib.Path, base_name: str, cbr_320: 
 	js_runtime_args = ytdlp_js_runtime_args(yt_bin)
 	cmd_base = [
 		yt_bin,
-		"-f", "bestaudio",
+		"-f", MP3_SOURCE_FORMAT,
 		"--no-playlist",
 		"--force-overwrites",
 		"--retries", "5",

--- a/csvmusic/core/update_check.py
+++ b/csvmusic/core/update_check.py
@@ -1,0 +1,63 @@
+# tabs only
+import datetime
+import re
+from dataclasses import dataclass
+
+import requests
+
+
+LATEST_RELEASE_URL = "https://api.github.com/repos/angall1/CSVMusic/releases/latest"
+CHECK_INTERVAL = datetime.timedelta(days=1)
+
+
+@dataclass(frozen=True)
+class UpdateInfo:
+	version: str
+	url: str
+
+
+def parse_release_version(value: str) -> tuple[int, int, int] | None:
+	match = re.fullmatch(r"v?(\d+)\.(\d+)\.(\d+)", (value or "").strip(), flags=re.IGNORECASE)
+	if match is None:
+		return None
+	return tuple(int(part) for part in match.groups())
+
+
+def should_check_for_updates(last_checked: str | None, *, now: datetime.datetime | None = None) -> bool:
+	if not last_checked:
+		return True
+	try:
+		checked_at = datetime.datetime.fromisoformat(last_checked.replace("Z", "+00:00"))
+	except (TypeError, ValueError):
+		return True
+	if checked_at.tzinfo is None:
+		checked_at = checked_at.replace(tzinfo=datetime.timezone.utc)
+	current = now or datetime.datetime.now(datetime.timezone.utc)
+	if current.tzinfo is None:
+		current = current.replace(tzinfo=datetime.timezone.utc)
+	return current - checked_at >= CHECK_INTERVAL
+
+
+def update_check_timestamp() -> str:
+	return datetime.datetime.now(datetime.timezone.utc).isoformat()
+
+
+def fetch_available_update(current_version: str, *, timeout: float = 8.0) -> UpdateInfo | None:
+	response = requests.get(
+		LATEST_RELEASE_URL,
+		headers={"Accept": "application/vnd.github+json", "User-Agent": f"CSVMusic/{current_version}"},
+		timeout=timeout,
+	)
+	response.raise_for_status()
+	payload = response.json()
+	if payload.get("draft") or payload.get("prerelease"):
+		return None
+	latest_text = str(payload.get("tag_name") or "").strip()
+	latest = parse_release_version(latest_text)
+	current = parse_release_version(current_version)
+	url = str(payload.get("html_url") or "").strip()
+	if latest is None or current is None or latest <= current:
+		return None
+	if not url.startswith("https://github.com/angall1/CSVMusic/releases/"):
+		return None
+	return UpdateInfo(version=".".join(str(part) for part in latest), url=url)

--- a/csvmusic/ui/main_window.py
+++ b/csvmusic/ui/main_window.py
@@ -11,17 +11,19 @@ from PySide6.QtWidgets import (
 	QComboBox, QSlider, QDialog, QInputDialog, QAbstractItemView,
 	QFileSystemModel, QTreeView, QDialogButtonBox
 )
-from PySide6.QtCore import Qt, QSignalBlocker, QUrl, Signal, QRect, QSize
+from PySide6.QtCore import Qt, QSignalBlocker, QUrl, Signal, QRect, QSize, QTimer
 from PySide6.QtGui import QColor, QFont, QIcon, QPixmap, QFontDatabase, QGuiApplication, QDesktopServices, QPainter, QPen
 
 from csvmusic.core.csv_import import load_csv, tracks_from_csv
 from csvmusic.core.settings import load_settings, save_settings
+from csvmusic.core.update_check import UpdateInfo, should_check_for_updates, update_check_timestamp
 from csvmusic.core.downloader import sanitize_name, youtube_batch_mitigation
 from csvmusic.core.preflight import run_preflight_checks
 from csvmusic.core.output_folder import OutputFolderError, validate_output_folder
 from csvmusic.core.track_output import expected_track_path, plan_track_outputs
 from csvmusic.core.paths import app_icon_path, resource_base
-from csvmusic.ui.workers import PipelineWorker, SingleDownloadWorker, CookiesCheckWorker, AlternativesFetchWorker, MusicURLImportWorker
+from csvmusic.ui.workers import PipelineWorker, SingleDownloadWorker, CookiesCheckWorker, AlternativesFetchWorker, MusicURLImportWorker, UpdateCheckWorker
+from csvmusic.version import APP_VERSION
 from csvmusic.core.browsers import list_profiles
 from csvmusic.core.youtube_url import YouTubeVideoUrlError, parse_youtube_video_id
 
@@ -299,6 +301,7 @@ class MainWindow(QMainWindow):
 		self.load_source_description: str = ""
 		self._allow_path_persist = False
 		self.cookie_check_worker: CookiesCheckWorker | None = None
+		self.update_check_worker: UpdateCheckWorker | None = None
 		icon_p = app_icon_path()
 		if icon_p:
 			self.setWindowIcon(QIcon(str(icon_p)))
@@ -1181,6 +1184,46 @@ class MainWindow(QMainWindow):
 		vl.addWidget(self.resolve_box)
 
 		self._load_last_session()
+		QTimer.singleShot(1500, self._start_update_check)
+
+	def _start_update_check(self) -> None:
+		if self.update_check_worker is not None and self.update_check_worker.isRunning():
+			return
+		settings = load_settings()
+		if not should_check_for_updates(settings.get("last_update_check_at")):
+			return
+		save_settings({"last_update_check_at": update_check_timestamp()})
+		self.update_check_worker = UpdateCheckWorker(APP_VERSION, self)
+		self.update_check_worker.sig_done.connect(self._on_update_check_finished)
+		self.update_check_worker.start()
+
+	def _on_update_check_finished(self, update: UpdateInfo | None) -> None:
+		worker = self.update_check_worker
+		self.update_check_worker = None
+		if worker is not None:
+			worker.deleteLater()
+		if update is None:
+			return
+		settings = load_settings()
+		if settings.get("skipped_update_version") == update.version:
+			return
+		message = QMessageBox(self)
+		message.setWindowTitle("Update Available")
+		message.setIcon(QMessageBox.Information)
+		message.setText(f"CSVMusic {update.version} is available.")
+		message.setInformativeText(
+			f"You are currently running CSVMusic {APP_VERSION}. Would you like to open the download page?"
+		)
+		download_button = message.addButton("Download Update", QMessageBox.AcceptRole)
+		message.addButton("Remind Me Later", QMessageBox.RejectRole)
+		skip_button = message.addButton("Skip This Version", QMessageBox.DestructiveRole)
+		message.exec()
+		clicked = message.clickedButton()
+		if clicked is download_button:
+			if not QDesktopServices.openUrl(QUrl(update.url)):
+				QMessageBox.warning(self, "Open Failed", f"Could not open {update.url}")
+		elif clicked is skip_button:
+			save_settings({"skipped_update_version": update.version})
 
 	def _compute_scale_factor(self) -> float:
 		screen = QGuiApplication.primaryScreen()
@@ -2918,6 +2961,10 @@ class MainWindow(QMainWindow):
 		# Stop cookie check worker if running
 		self._shutdown_thread(self.cookie_check_worker, wait_ms=500)
 		self.cookie_check_worker = None
+
+		# Stop update check worker if startup is still waiting on the network
+		self._shutdown_thread(self.update_check_worker, wait_ms=500)
+		self.update_check_worker = None
 
 		# Stop resolution workers if running
 		for record in list(self.resolve_items.values()):

--- a/csvmusic/ui/workers.py
+++ b/csvmusic/ui/workers.py
@@ -20,8 +20,25 @@ from csvmusic.core.downloader import (
 )
 from csvmusic.core.paths import ytdlp_path as _resolve_ytdlp, INTERNAL_YTDLP
 from csvmusic.core.subprocess_env import subprocess_kwargs
+from csvmusic.core.update_check import UpdateInfo, fetch_available_update
 
 _FORCE_FALLBACK_MIN_SCORE = 0.45
+
+
+class UpdateCheckWorker(QThread):
+	sig_done = Signal(object)
+
+	def __init__(self, current_version: str, parent: QObject | None = None):
+		super().__init__(parent)
+		self.current_version = current_version
+
+	def run(self):
+		update: UpdateInfo | None = None
+		try:
+			update = fetch_available_update(self.current_version)
+		except Exception as exc:
+			log(f"update check unavailable: {exc}")
+		self.sig_done.emit(update)
 
 class MusicURLImportWorker(QThread):
 	sig_done = Signal(bool, dict, str)

--- a/csvmusic/version.py
+++ b/csvmusic/version.py
@@ -1,2 +1,2 @@
 # tabs only
-APP_VERSION = "1.6.4"
+APP_VERSION = "1.6.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "csvmusic"
-version = "1.6.4"
+version = "1.6.5"
 description = "Convert Spotify playlists to MP3/M4A via YouTube Music (packaged, no extra installs)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/core/test_downloader.py
+++ b/tests/core/test_downloader.py
@@ -8,6 +8,10 @@ def test_youtube_client_fallbacks_use_current_client_names():
 	assert "webremix" not in downloader.YOUTUBE_CLIENTS
 
 
+def test_mp3_source_format_falls_back_to_combined_stream():
+	assert downloader.MP3_SOURCE_FORMAT == "bestaudio/best"
+
+
 def test_auth_required_errors_do_not_retry_without_cookies():
 	assert not downloader._should_retry_without_cookies(
 		"ERROR: Sign in to confirm your age",

--- a/tests/core/test_update_check.py
+++ b/tests/core/test_update_check.py
@@ -1,0 +1,62 @@
+import datetime
+
+from csvmusic.core import update_check
+
+
+class FakeResponse:
+	def __init__(self, payload: dict):
+		self.payload = payload
+
+	def raise_for_status(self) -> None:
+		pass
+
+	def json(self) -> dict:
+		return self.payload
+
+
+def test_parse_release_version_accepts_github_tag():
+	assert update_check.parse_release_version("v1.6.4") == (1, 6, 4)
+	assert update_check.parse_release_version("1.7.0") == (1, 7, 0)
+	assert update_check.parse_release_version("nightly") is None
+
+
+def test_update_check_is_due_once_per_day():
+	now = datetime.datetime(2026, 8, 20, 12, tzinfo=datetime.timezone.utc)
+
+	assert not update_check.should_check_for_updates("2026-08-20T00:00:01+00:00", now=now)
+	assert update_check.should_check_for_updates("2026-08-19T11:59:59+00:00", now=now)
+	assert update_check.should_check_for_updates("invalid", now=now)
+
+
+def test_fetch_available_update_returns_newer_stable_release(monkeypatch):
+	monkeypatch.setattr(update_check.requests, "get", lambda *_args, **_kwargs: FakeResponse({
+		"tag_name": "v1.7.0",
+		"html_url": "https://github.com/angall1/CSVMusic/releases/tag/v1.7.0",
+		"draft": False,
+		"prerelease": False,
+	}))
+
+	result = update_check.fetch_available_update("1.6.4")
+
+	assert result == update_check.UpdateInfo(
+		version="1.7.0",
+		url="https://github.com/angall1/CSVMusic/releases/tag/v1.7.0",
+	)
+
+
+def test_fetch_available_update_ignores_current_or_sketchy_release(monkeypatch):
+	monkeypatch.setattr(update_check.requests, "get", lambda *_args, **_kwargs: FakeResponse({
+		"tag_name": "v1.6.4",
+		"html_url": "https://github.com/angall1/CSVMusic/releases/tag/v1.6.4",
+		"draft": False,
+		"prerelease": False,
+	}))
+	assert update_check.fetch_available_update("1.6.4") is None
+
+	monkeypatch.setattr(update_check.requests, "get", lambda *_args, **_kwargs: FakeResponse({
+		"tag_name": "v9.9.9",
+		"html_url": "https://example.com/not-csvmusic",
+		"draft": False,
+		"prerelease": False,
+	}))
+	assert update_check.fetch_available_update("1.6.4") is None


### PR DESCRIPTION
## Summary
- add startup notifications for newer stable CSVMusic releases
- fall back to combined YouTube streams when audio-only MP3 sources are unavailable
- update the README front-page notes and download links for v1.6.5

## Validation
- 82 automated tests passed
- local Windows PyInstaller build launched successfully
- live MP3 download passed for the previously failing video