### PR TITLE
Release CSVMusic 1.6.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,21 +23,21 @@ CSVMusic accepts playlist and album links from supported music services, or a pl
 # Download
 
 Go here:
-https://github.com/angall1/CSVMusic/releases/tag/v1.6.5
+https://github.com/angall1/CSVMusic/releases/tag/v1.6.6
 
 Download one of the following based on your OS:
 
 ### Windows
-https://github.com/angall1/CSVMusic/releases/download/v1.6.5/CSVMusic-windows.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.6/CSVMusic-windows.zip
 
 ### macOS (Apple Silicon)
-https://github.com/angall1/CSVMusic/releases/download/v1.6.5/CSVMusic-macos-arm64.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.6/CSVMusic-macos-arm64.zip
 
 ### macOS (Intel)
-https://github.com/angall1/CSVMusic/releases/download/v1.6.5/CSVMusic-macos-intel.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.6/CSVMusic-macos-intel.zip
 
 ### Linux
-https://github.com/angall1/CSVMusic/releases/download/v1.6.5/CSVMusic-linux.zip
+https://github.com/angall1/CSVMusic/releases/download/v1.6.6/CSVMusic-linux.zip
 
 Extract the ZIP before running the app. If your desktop does not launch the files directly, open a terminal in the extracted folder and run:
 
@@ -64,7 +64,7 @@ Python installations still require a supported graphical desktop environment for
 
 ---
 
-# What's New In 1.6.5 (Since 1.6.0)
+# What's New In 1.6.6 (Since 1.6.0)
 
 ## Updates and MP3 reliability
 
@@ -73,6 +73,8 @@ Python installations still require a supported graphical desktop environment for
 
 ## YouTube reliability
 
+- Fixed preflight incorrectly reporting the bundled yt-dlp as too old when antivirus scanning or slower storage made its version probe take more than three seconds.
+- Added yt-dlp's automatic YouTube client selection as an early fallback, allowing current upstream clients such as `visionos` to recover when a forced client temporarily exposes no playable formats.
 - Updated and pinned yt-dlp to `2026.08.19`, fixing widespread HTTP 403 failures with current YouTube `web_embedded` downloads and preventing release builds from silently changing downloader versions.
 - Fixed current YouTube player-challenge failures by packaging Deno and `yt-dlp-ejs`, passing the runtime explicitly, and validating both before downloads begin.
 - Updated YouTube client fallbacks and diagnostics for current yt-dlp behavior, including clearer HTTP 403, throttling, and JavaScript-runtime messages.
@@ -88,6 +90,7 @@ Python installations still require a supported graphical desktop environment for
 
 ## Audio and Windows packaging
 
+- Shortened exceptionally long track filenames with a stable uniqueness suffix, preventing Windows output-path failures from being misreported as YouTube throttling.
 - Added optional native **Opus** output under Settings. Opus streams are remuxed without lossy re-encoding and support metadata and artwork.
 - Prevented FFmpeg failures caused by selecting Apple Music or iTunes auto-import folders.
 - Fixed Windows release builds by accepting Deno's PowerShell-formatted SHA256 metadata while retaining archive integrity verification on every platform.

--- a/csvmusic/core/downloader.py
+++ b/csvmusic/core/downloader.py
@@ -1,5 +1,5 @@
 # tabs only
-import os, pathlib, subprocess, requests, io, contextlib, json, base64
+import os, pathlib, subprocess, requests, io, contextlib, json, base64, hashlib
 from dataclasses import dataclass
 from typing import Dict, Optional, List
 import re, unicodedata
@@ -15,7 +15,7 @@ from csvmusic.core.subprocess_env import subprocess_kwargs
 
 YTM_URL = "https://music.youtube.com/watch?v={vid}"
 YT_URL = "https://www.youtube.com/watch?v={vid}"
-YOUTUBE_CLIENTS: list[str] = ["web_embedded", "ios", "tv", "android_vr"]
+YOUTUBE_CLIENTS: list[str | None] = ["web_embedded", None, "ios", "tv", "android_vr"]
 MP3_SOURCE_FORMAT = "bestaudio/best"
 _YOUTUBE_RISK_PATTERNS: tuple[tuple[str, str], ...] = (
 	("http error 429", "YouTube returned HTTP 429"),
@@ -79,6 +79,7 @@ YOUTUBE_MITIGATION_AGGRESSIVE = YouTubeMitigationProfile(
 
 _TARGET_LOUDNESS_I = -16.0
 _TARGET_TRUE_PEAK_DB = -2.5
+_MAX_SAFE_NAME_LENGTH = 140
 
 def _run(cmd: list[str]) -> int:
 	proc = _run_capture(cmd)
@@ -344,7 +345,12 @@ def sanitize_name(name: str) -> str:
 	text = re.sub(r"[\x00-\x1f]+", "", text)
 	text = re.sub(r"\s+", " ", text).strip()
 	text = text.rstrip(". ")
-	return text or "_"
+	text = text or "_"
+	if len(text) <= _MAX_SAFE_NAME_LENGTH:
+		return text
+	digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:10]
+	prefix_length = _MAX_SAFE_NAME_LENGTH - len(digest) - 1
+	return f"{text[:prefix_length].rstrip()}-{digest}"
 
 def _safe(name: str) -> str:
 	# Backward-compatible helper kept for internal use
@@ -621,7 +627,9 @@ def tag_file(path: pathlib.Path, meta: Dict, cover_bytes: Optional[bytes], *, co
 		mp4.save()
 
 
-def _extractor_args(client: str) -> list[str]:
+def _extractor_args(client: str | None) -> list[str]:
+	if client is None:
+		return []
 	return ["--extractor-args", f"youtube:player_client={client}"]
 
 

--- a/csvmusic/core/js_runtime.py
+++ b/csvmusic/core/js_runtime.py
@@ -7,6 +7,7 @@ from csvmusic.core.paths import INTERNAL_YTDLP, deno_path
 from csvmusic.core.subprocess_env import subprocess_kwargs
 
 _MIN_YTDLP_JS_RUNTIMES = (2026, 6, 9)
+_VERSION_PROBE_TIMEOUT_S = 15
 
 
 @dataclass(frozen=True)
@@ -34,7 +35,7 @@ def _run_version(path: str) -> str:
 		stdout=subprocess.PIPE,
 		stderr=subprocess.STDOUT,
 		text=True,
-		timeout=3,
+		timeout=_VERSION_PROBE_TIMEOUT_S,
 		**subprocess_kwargs(),
 	)
 	return (proc.stdout or "").strip().splitlines()[0] if proc.stdout else ""

--- a/csvmusic/core/preflight.py
+++ b/csvmusic/core/preflight.py
@@ -173,8 +173,8 @@ def _check_js_runtime(errors: List[str], warnings: List[str], details: Dict[str,
 		return
 	if not ytdlp_supports_js_runtimes(yt_bin):
 		errors.append(
-			"A supported JavaScript runtime is installed, but this yt-dlp version is too old for CSVMusic to enable it automatically. "
-			"Update yt-dlp with the default extras."
+			"A supported JavaScript runtime is installed, but CSVMusic could not confirm that yt-dlp supports runtime selection. "
+			"Retry preflight or update to yt-dlp 2026.06.09+ with the default extras."
 		)
 
 

--- a/csvmusic/version.py
+++ b/csvmusic/version.py
@@ -1,2 +1,2 @@
 # tabs only
-APP_VERSION = "1.6.5"
+APP_VERSION = "1.6.6"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "csvmusic"
-version = "1.6.5"
+version = "1.6.6"
 description = "Convert Spotify playlists to MP3/M4A via YouTube Music (packaged, no extra installs)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/tests/core/test_downloader.py
+++ b/tests/core/test_downloader.py
@@ -4,8 +4,10 @@ import unicodedata
 
 def test_youtube_client_fallbacks_use_current_client_names():
 	assert downloader.YOUTUBE_CLIENTS[0] == "web_embedded"
+	assert downloader.YOUTUBE_CLIENTS[1] is None
 	assert "tv_embedded" not in downloader.YOUTUBE_CLIENTS
 	assert "webremix" not in downloader.YOUTUBE_CLIENTS
+	assert downloader._extractor_args(None) == []
 
 
 def test_mp3_source_format_falls_back_to_combined_stream():
@@ -83,6 +85,16 @@ def test_cleanup_outputs_removes_decomposed_accents(tmp_path):
 	downloader._cleanup_outputs(tmp_path, base)
 
 	assert not path.exists()
+
+
+def test_sanitize_name_shortens_long_windows_filenames_deterministically():
+	first = downloader.sanitize_name("Orchestra - " + "A" * 300)
+	second = downloader.sanitize_name("Orchestra - " + "B" * 300)
+
+	assert len(first) == downloader._MAX_SAFE_NAME_LENGTH
+	assert len(second) == downloader._MAX_SAFE_NAME_LENGTH
+	assert first != second
+	assert first == downloader.sanitize_name("Orchestra - " + "A" * 300)
 
 
 def test_tag_file_writes_mp3_track_and_disc_numbers(monkeypatch, tmp_path):

--- a/tests/core/test_js_runtime.py
+++ b/tests/core/test_js_runtime.py
@@ -1,6 +1,21 @@
 from unittest.mock import patch
 
+from csvmusic.core import js_runtime
 from csvmusic.core.js_runtime import JsRuntimeInfo, ytdlp_js_runtime_args
+
+
+def test_current_date_version_supports_js_runtimes():
+	js_runtime.ytdlp_supports_js_runtimes.cache_clear()
+	with patch("csvmusic.core.js_runtime._yt_dlp_version", return_value="2026.08.19"):
+		assert js_runtime.ytdlp_supports_js_runtimes("yt-dlp.exe")
+	js_runtime.ytdlp_supports_js_runtimes.cache_clear()
+
+
+def test_version_probe_allows_slow_standalone_startup():
+	with patch("csvmusic.core.js_runtime.subprocess.run") as run:
+		run.return_value.stdout = "2026.08.19\n"
+		assert js_runtime._run_version("yt-dlp.exe") == "2026.08.19"
+		assert run.call_args.kwargs["timeout"] == 15
 
 
 def test_ytdlp_js_runtime_args_enable_supported_node():


### PR DESCRIPTION
## Summary
- allow yt-dlp automatic client selection before legacy client fallbacks
- prevent long Windows track paths from being misreported as YouTube throttling
- fix false preflight failures for slower standalone yt-dlp version probes
- update cumulative README notes and links for v1.6.6

## Validation
- 85 automated tests passed
- exact 24-track Spotify playlist imported and all matched IDs resolved
- real MP3 conversions passed for the first track and the previously failing long-title track
- final Windows PyInstaller candidate built and launched successfully